### PR TITLE
appsWithVersion and appsWithMvnVersion backwards compatibility

### DIFF
--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/deployments/DeploymentsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/deployments/DeploymentsRest.java
@@ -385,13 +385,10 @@ public class DeploymentsRest {
             for (ResourceEntity app : apps) {
                 // if the name matches, convert the app
                 if (requestedApp.getApplicationName().equals(app.getName())) {
-                    //for backwards compatibility: use MavenVersion as Version
-                    String appVersion = (requestedApp.getMavenVersion() != null && !requestedApp.getMavenVersion().isEmpty())
-                            ? requestedApp.getMavenVersion() : requestedApp.getVersion();
                     //convert
                     result.add(
                             new ApplicationWithVersion(
-                                    requestedApp.getApplicationName(), app.getId(), appVersion));
+                                    requestedApp.getApplicationName(), app.getId(), requestedApp.getVersion()));
                     //scratch off
                     requestedAppsCopy.remove(requestedApp);
                     appsCopy.remove(app);

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/AppWithMvnVersionDTO.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/AppWithMvnVersionDTO.java
@@ -27,19 +27,24 @@ import javax.xml.bind.annotation.XmlRootElement;
 import lombok.Getter;
 import lombok.Setter;
 
-@XmlRootElement(name = "appWithVersion")
+/**
+* @deprecated Only here for backwards compatibility of the rest API
+*/
+@XmlRootElement(name = "appWithMvnVersion")
 @XmlAccessorType(XmlAccessType.FIELD)
 @Getter @Setter
-public class AppWithVersionDTO {
-	
+@Deprecated
+public class AppWithMvnVersionDTO {
+
 	private String applicationName;
-	private String version;
-	
-	public AppWithVersionDTO() {}
-	
-	public AppWithVersionDTO(String applicationName, String version) {
-		this.applicationName = applicationName;
-		this.version = version;
+	private String mavenVersion;
+
+	public AppWithMvnVersionDTO() {
 	}
-	
+
+	public AppWithMvnVersionDTO(String applicationName, String mavenVersion) {
+		this.applicationName = applicationName;
+		this.mavenVersion = mavenVersion;
+	}
+
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/DeploymentDTO.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/DeploymentDTO.java
@@ -38,7 +38,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @XmlRootElement(name = "deployment")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @Getter @Setter
 public class DeploymentDTO {
 
@@ -81,7 +81,19 @@ public class DeploymentDTO {
 		for (NodeJobEntity job : entity.getNodeJobs()) {
 			nodeJobs.add(new NodeJobDTO(job));
 		}
-		
 	}
 
+	/**
+	 * @deprecated Only here for backwards compatibility of the rest API
+	 */
+	@Deprecated
+	public List<AppWithMvnVersionDTO> getAppsWithMvnVersion() {
+		List<AppWithMvnVersionDTO> appsWithMvnVersion = new LinkedList<>();
+
+		for(AppWithVersionDTO app : this.appsWithVersion) {
+			appsWithMvnVersion.add(new AppWithMvnVersionDTO(app.getApplicationName(), app.getVersion()));
+		}
+		
+		return appsWithMvnVersion;
+	}
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/DeploymentRequestDTO.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/DeploymentRequestDTO.java
@@ -31,7 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 @XmlRootElement(name = "deploymentRequest")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @Getter @Setter
 public class DeploymentRequestDTO {
 	
@@ -49,6 +49,23 @@ public class DeploymentRequestDTO {
 	private List<DeploymentParameterDTO> deploymentParameters; // optional
 	
 	public DeploymentRequestDTO() {	
+	}
+	
+	/**
+	 * @deprecated Only here for backwards compatibility of the rest API
+	 */
+	@Deprecated
+	public void setAppsWithMvnVersion(List<AppWithMvnVersionDTO> appsWithMvnVersion) {
+		if (appsWithMvnVersion == null) {
+			this.appsWithVersion = null;
+			return;
+		}
+		
+		this.appsWithVersion = new LinkedList<>();
+		
+		for(AppWithMvnVersionDTO app : appsWithMvnVersion) {
+			this.appsWithVersion.add(new AppWithVersionDTO(app.getApplicationName(), app.getMavenVersion()));
+		}
 	}
 	
 	//copy constructor


### PR DESCRIPTION
Damit die rest Schnittstelle rückwärtskompatibel bleibt, werden beide Strukturen geführt.
Beispiel deployment Response:
```
    "appsWithVersion": [
      {
        "applicationName": "ch_puzzle_itc_moby_amw",
        "version": "123"
      }
    ],
    "apdpsWithMvnVersion": [
      {
        "applicationName": "ch_puzzle_itc_moby_amw",
        "mavenVersion": "123"
      }
```
Gleiches gilt für Requests.